### PR TITLE
last mile for traefik dns challenge

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
 version: 1.18.0
-appVersion: 1.4.6
+appVersion: 1.5.1
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.18.0
+version: 1.19.0
 appVersion: 1.5.1
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -104,7 +104,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `ssl.defaultCert`               | Base64 encoded default certficate                                    | A self-signed certificate                 |
 | `ssl.defaultKey`                | Base64 encoded private key for the certificate above                 | The private key for the certificate above |
 | `acme.enabled`                  | Whether to use Let's Encrypt to obtain certificates                  | `false`                                   |
-| `acme.challengeType`            | Type of ACME challenge to perform domain validation. `http-01` or `dns-01` | `http-01`                                 |
+| `acme.challengeType`            | Type of ACME challenge to perform domain validation. `tls-sni-01` or `dns-01` | `tls-sni-01`                     |
 | `acme.dnsProvider.name`         | Which DNS provider to use. See [here](https://github.com/xenolf/lego/tree/master/providers/dns) for the list of possible values. | `nil`                                     |
 | `acme.dnsProvider.$name`        | The configuration environment variables (encoded as a secret) needed for the DNS provider to do DNS challenge. See [here](#example-aws-route-53). | `{}`                     |
 | `acme.email`                    | Email address to be used in certificates obtained from Let's Encrypt | `admin@example.com`                       |

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -68,14 +68,15 @@ data:
     storage = "/acme/acme.json"
     entryPoint = "https"
     onHostRule = true
-    {{- if eq .Values.acme.challengeType "dns-01" }}
-    dnsProvider = "{{ .Values.acme.dnsProvider.name }}"
-    {{- end }}
     {{- if .Values.acme.staging }}
     caServer = "https://acme-staging.api.letsencrypt.org/directory"
     {{- end }}
     {{- if .Values.acme.logging }}
     acmeLogging = true
+    {{- end }}
+    {{- if eq .Values.acme.challengeType "dns-01" }}
+      [acme.dnsChallenge]
+      provider = "{{ .Values.acme.dnsProvider.name }}"
     {{- end }}
     {{- end }}
     {{- if or .Values.dashboard.enabled .Values.metrics.prometheus.enabled .Values.metrics.statsd.enabled .Values.metrics.datadog.enabled }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 ## Default values for Traefik
 image: traefik
-imageTag: 1.4.6
+imageTag: 1.5.1
 ## can switch the service type to NodePort if required
 serviceType: LoadBalancer
 loadBalancerIP:

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -192,10 +192,3 @@ deployment:
     httpEnabled: false
     httpsEnabled: false
     dashboardEnabled: false
-## Environment variables for the Traefik pod
-env:
-# Kubernetes ingress filters
-# kubernetes:
-#   namespaces:
-#   - default
-#   labelSelector:

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -34,8 +34,15 @@ acme:
   email: admin@example.com
   staging: true
   logging: false
-  challengeType: "http-01"  # http-01 or dns-01
-  ## Set dnsProvider to perform domain verification using dns challenge
+  ## ACME challenge type: "tls-sni-01" or "dns-01"
+  ## Note the chart's default of tls-sni-01 has been DEPRECATED and (except in
+  ## certain circumstances) DISABLED by Let's Encrypt. It remains as a default
+  ## value in this chart to preserve legacy behavior and avoid a breaking
+  ## change. Users of this chart should strongly consider making the switch to
+  ## the dns-01 challenge.
+  challengeType: tls-sni-01
+  ## Configure dnsProvider to perform domain verification using dns challenge
+  ## Applicable only if using the dns-01 challenge type
   dnsProvider:
     name: nil
     auroradns:


### PR DESCRIPTION
@kevinjqiu I had some time on my hands today, so here's a helping hand getting https://github.com/kubernetes/charts/pull/1299 over the finish line.

I tested this with Azure as the DNS provider. It might not be a bad idea to validate these changes with your own DNS provider.

Note the Traefik version bump is required to get support for the `[acme.dnsChallenge]` section that replaces the old / deprecated way of configuring ACME to use the DNS challenge.